### PR TITLE
Fix #7: Don't show the 'invalid syntax' message for real-time scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**[0.8.1] 2018-09-08**
+ - Fix #7: Don't show the 'invalid syntax' message for real-time scan.
+
 **[0.8.0] 2018-09-05**
  - Fix #2: Showing better info to the user if Mypy is missing.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version=0.8.0
+version=0.8.1
 ideaVersion=2016.1
 sinceBuild=145.258
 untilBuild=

--- a/src/main/java/com/leinardi/pycharm/mypy/MypyInspection.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyInspection.java
@@ -48,6 +48,7 @@ public class MypyInspection extends LocalInspectionTool {
 
     private static final Logger LOG = Logger.getInstance(MypyInspection.class);
     private static final List<Problem> NO_PROBLEMS_FOUND = Collections.emptyList();
+    private static final String ERROR_MESSAGE_INVALID_SYNTAX = "invalid syntax";
 
     private MypyPlugin plugin(final Project project) {
         final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
@@ -85,6 +86,8 @@ public class MypyInspection extends LocalInspectionTool {
             }
             ScanFiles scanFiles = new ScanFiles(plugin, Collections.singletonList(psiFile.getVirtualFile()));
             Map<PsiFile, List<Problem>> map = scanFiles.call();
+            map.values().forEach(problems -> problems.removeIf(problem ->
+                    problem.getMessage().equals(ERROR_MESSAGE_INVALID_SYNTAX)));
             if (map.isEmpty()) {
                 return NO_PROBLEMS_FOUND;
             }


### PR DESCRIPTION
Closes #7 