### PR TITLE
Use dmypy instead of mypy

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/MypyConfigService.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyConfigService.java
@@ -31,11 +31,13 @@ public class MypyConfigService implements PersistentStateComponent<MypyConfigSer
     private String mypyConfigFilePath;
     private String mypyArguments;
     private boolean scanBeforeCheckin;
+    private boolean useDaemon;
 
     public MypyConfigService() {
         customMypyPath = "";
         mypyArguments = "";
         mypyConfigFilePath = "";
+        useDaemon = true;
     }
 
     public String getCustomMypyPath() {
@@ -68,6 +70,14 @@ public class MypyConfigService implements PersistentStateComponent<MypyConfigSer
 
     public void setScanBeforeCheckin(boolean scanBeforeCheckin) {
         this.scanBeforeCheckin = scanBeforeCheckin;
+    }
+
+    public boolean isUseDaemon() {
+        return useDaemon;
+    }
+
+    public void setUseDaemon(boolean useDaemon) {
+        this.useDaemon = useDaemon;
     }
 
     @Nullable

--- a/src/main/java/com/leinardi/pycharm/mypy/MypyConfigService.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyConfigService.java
@@ -37,7 +37,7 @@ public class MypyConfigService implements PersistentStateComponent<MypyConfigSer
         customMypyPath = "";
         mypyArguments = "";
         mypyConfigFilePath = "";
-        useDaemon = true;
+        useDaemon = false;
     }
 
     public String getCustomMypyPath() {

--- a/src/main/java/com/leinardi/pycharm/mypy/MypyConfigurable.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyConfigurable.java
@@ -68,7 +68,8 @@ public class MypyConfigurable implements Configurable {
     public boolean isModified() {
         boolean result = !configPanel.getMypyPath().equals(mypyConfigService.getCustomMypyPath())
                 || !configPanel.getMypyConfigFilePath().equals(mypyConfigService.getMypyConfigFilePath())
-                || !configPanel.getMypyArguments().equals(mypyConfigService.getMypyArguments());
+                || !configPanel.getMypyArguments().equals(mypyConfigService.getMypyArguments())
+                || !configPanel.getUseDaemon() == (mypyConfigService.isUseDaemon());
         if (LOG.isDebugEnabled()) {
             LOG.debug("Has config changed? " + result);
         }
@@ -80,6 +81,7 @@ public class MypyConfigurable implements Configurable {
         mypyConfigService.setCustomMypyPath(configPanel.getMypyPath());
         mypyConfigService.setMypyConfigFilePath(configPanel.getMypyConfigFilePath());
         mypyConfigService.setMypyArguments(configPanel.getMypyArguments());
+        mypyConfigService.setUseDaemon(configPanel.getUseDaemon());
     }
 
     @Override

--- a/src/main/java/com/leinardi/pycharm/mypy/checker/ScannableFile.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/checker/ScannableFile.java
@@ -190,7 +190,7 @@ public class ScannableFile {
     }
 
     private File prepareBaseTmpDirFor(final PsiFile tempPsiFile) {
-        final File baseTmpDir = new File(new TempDirProvider().forPersistedPsiFile(tempPsiFile),
+        final File baseTmpDir = new File(new TempDirProvider(tempPsiFile.getProject()).forPersistedPsiFile(tempPsiFile),
                 tempFileDirectoryName());
         baseTmpDir.deleteOnExit();
         return baseTmpDir;

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -278,13 +278,6 @@ public class MypyRunner {
         }
 
         cmd.addParameter("--show-column-numbers");
-        cmd.addParameter("--follow-imports");
-
-        if (daemon) {
-            cmd.addParameter("error");
-        } else {
-            cmd.addParameter("silent");
-        }
 
         injectEnvironmentVariables(project, cmd);
 

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -87,12 +87,9 @@ public class MypyRunner {
             return false;
         }
         GeneralCommandLine cmd = getMypyCommandLine(project, mypyPath);
-        boolean daemon = false;
-        if (daemon) {
-            cmd.addParameter("status");
-        } else {
-            cmd.addParameter("-V");
-        }
+
+        cmd.addParameter("-V");
+
         final Process process;
         try {
             process = cmd.createProcess();

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -268,11 +268,10 @@ public class MypyRunner {
         if (filesToScan.isEmpty()) {
             return Collections.emptyList();
         }
-        boolean daemon = true;
 
         GeneralCommandLine cmd = new GeneralCommandLine(mypyPath);
         cmd.setCharset(UTF_8);
-        if (daemon) {
+        if (mypyConfigService.isUseDaemon()) {
             cmd.addParameter("run");
             cmd.addParameter("--");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -276,7 +276,7 @@ public class MypyRunner {
         if (daemon) {
             cmd.addParameter("run");
             cmd.addParameter("--");
-            cmd.addParameter("``--show-column-numbers");
+            cmd.addParameter("--show-column-numbers");
         } else {
             cmd.addParameter("--show-column-numbers");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -46,6 +46,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -267,6 +269,14 @@ public class MypyRunner {
             throws InterruptedIOException, InterruptedException {
         if (filesToScan.isEmpty()) {
             return Collections.emptyList();
+        }
+
+        if (mypyConfigService.isUseDaemon()) {
+            // build path to dmypy by assuming that it sits right next to the selected mypy executable
+            // with the only difference being that the name has "dmypy" in it rather than just "mypy"
+            Path p = Paths.get(mypyPath);
+            String dFile = p.getFileName().toString().replace("mypy", "dmypy");
+            mypyPath = Paths.get(p.getParent().toString(), dFile).toString();
         }
 
         GeneralCommandLine cmd = new GeneralCommandLine(mypyPath);

--- a/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.form
+++ b/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.leinardi.pycharm.mypy.ui.MypyConfigPanel">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="667" height="184"/>
@@ -37,7 +37,7 @@
       </component>
       <vspacer id="1b350">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="90410" class="com.intellij.ui.components.JBLabel">
@@ -69,6 +69,14 @@
           <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+      </component>
+      <component id="14b64" class="com.intellij.ui.components.JBCheckBox" binding="useDaemonCheckBox">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Use Daemon"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBTextField;
 import com.leinardi.pycharm.mypy.MypyBundle;
 import com.leinardi.pycharm.mypy.MypyConfigService;
@@ -39,6 +40,7 @@ public class MypyConfigPanel {
     private com.intellij.openapi.ui.TextFieldWithBrowseButton mypyPathField;
     private com.intellij.openapi.ui.TextFieldWithBrowseButton mypyConfigFilePathField;
     private JBTextField argumentsField;
+    private JBCheckBox useDaemonCheckBox;
     private Project project;
 
     public MypyConfigPanel(Project project) {
@@ -91,6 +93,8 @@ public class MypyConfigPanel {
     public String getMypyArguments() {
         return argumentsField.getText();
     }
+
+    public boolean getUseDaemon() { return useDaemonCheckBox.isSelected(); }
 
     private void createUIComponents() {
         JBTextField autodetectTextField = new JBTextField();

--- a/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/ui/MypyConfigPanel.java
@@ -68,6 +68,7 @@ public class MypyConfigPanel {
                 TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT);
         argumentsField.setText(mypyConfigService.getMypyArguments());
         argumentsField.getEmptyText().setText(MypyBundle.message("config.optional"));
+        useDaemonCheckBox.setSelected(mypyConfigService.isUseDaemon());
     }
 
     public JPanel getPanel() {

--- a/src/main/java/com/leinardi/pycharm/mypy/util/TempDirProvider.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/util/TempDirProvider.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.components.impl.stores.IProjectStore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.leinardi.pycharm.mypy.MypyConfigService;
 import org.jdesktop.swingx.util.OS;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,9 +35,16 @@ import java.util.Optional;
  * Locate and/or create temporary directories for use by this plugin.
  */
 public class TempDirProvider {
+    public TempDirProvider(Project project) {
+        this.mypyConfigService = MypyConfigService.getInstance(project);
+    }
+
+    private final MypyConfigService mypyConfigService;
+
     public String forPersistedPsiFile(final PsiFile tempPsiFile) {
         String systemTempDir = System.getProperty("java.io.tmpdir");
-        if (OS.isWindows() && driveLetterOf(systemTempDir) != driveLetterOf(pathOf(tempPsiFile))) {
+        if (mypyConfigService.isUseDaemon() || (OS.isWindows() && driveLetterOf(systemTempDir) != driveLetterOf(pathOf(tempPsiFile)))) {
+            // for some reason the daemon reports no errors unless the file is in the project directory
             // Some tool on Windows requires the files to be on the same drive
             final File projectTempDir = temporaryDirectoryLocationFor(tempPsiFile.getProject());
             if (projectTempDir.exists() || projectTempDir.mkdirs()) {


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * IntelliJ IDEA 2019.3.1
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This PR intends to either switch this plugin over to use dmypy completely, or at least provide an option to do so. Using dmypy is much faster and efficient than using mypy, it will allow sub-second scans compared to the 5-15 seconds it could take for mypy to do the same task.

There is still some work left to do. E.g. deciding whether we should just always use dmypy or whether it should be configurable (and how that should work). A fix/solution is also needed to compensate for the fact that dmypy does not support `--follow-imports silent`. I'm proposing that the function that parses the mypy output can filter out any errors produced by `--follow-imports error` and that we default to that option instead.

Lastly, it probably just needs a tad more testing (e.g. in PyCharm, and perhaps some other projects).

Nonetheless, the code in this PR serves as a proof-of-concept for now, and I intend to follow through with getting it into a merge-able state as long as some decisions on the above are made.


### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |

### Related Issue

Closes #57 
Closes #43
<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:

Closes #XXX 
-->
