### PR TITLE
Fix display of error messages with colon

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -38,6 +38,7 @@ import com.leinardi.pycharm.mypy.exception.MypyToolException;
 import com.leinardi.pycharm.mypy.util.FileTypes;
 import com.leinardi.pycharm.mypy.util.Notifications;
 import org.jdesktop.swingx.util.OS;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
@@ -304,6 +305,7 @@ public class MypyRunner {
         try {
             process = cmd.createProcess();
             InputStream inputStream = process.getInputStream();
+            assert (inputStream != null);
             //TODO check stderr for errors
             //            process.waitFor();
             return parseMypyOutput(inputStream);
@@ -319,7 +321,8 @@ public class MypyRunner {
         }
     }
 
-    private static List<Issue> parseMypyOutput(InputStream inputStream) throws IOException {
+    @NotNull
+    public static List<Issue> parseMypyOutput(@NotNull InputStream inputStream) throws IOException {
         ArrayList<Issue> issues = new ArrayList<>();
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream, UTF_8));
         String rawLine;
@@ -333,7 +336,7 @@ public class MypyRunner {
                     String path = splitPosition[0].trim();
                     int line = splitPosition.length > 1 ? Integer.parseInt(splitPosition[1].trim()) : 1;
                     int column = splitPosition.length > 2 ? Integer.parseInt(splitPosition[2].trim()) : 1;
-                    String[] splitError = rawLine.substring(typeIndexStart).split(":", -1);
+                    String[] splitError = rawLine.substring(typeIndexStart).split(":", 2);
                     SeverityLevel severityLevel = SeverityLevel.valueOf(splitError[0].trim().toUpperCase());
                     String message = splitError[1].trim();
                     issues.add(new Issue(path, line, column, severityLevel, message));

--- a/src/test/java/com/leinardi/pycharm/mypy/mpapi/MypyRunnerTest.java
+++ b/src/test/java/com/leinardi/pycharm/mypy/mpapi/MypyRunnerTest.java
@@ -1,0 +1,20 @@
+package com.leinardi.pycharm.mypy.mpapi;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class MypyRunnerTest {
+    @Test
+    public void testParseWithColon() throws IOException {
+        String message = "Dict entry 0 has incompatible type \"int\": \"str\"; expected \"int\": \"int\"  [dict-item]";
+        String input = "path/testfile.py:1:22: error: " + message + "\n";
+        Issue parsed = new Issue("path/testfile.py", 1, 22, SeverityLevel.ERROR, message);
+
+        List<Issue> results = MypyRunner.parseMypyOutput(new ByteArrayInputStream(input.getBytes()));
+        Assert.assertArrayEquals(results.toArray(), new Issue[]{parsed});
+    }
+}


### PR DESCRIPTION
Previously error message was truncated where a colon appeared.

Before:
```
Dict entry 0 has incompatible type "int"
```
After
```
Dict entry 0 has incompatible type "int": "str"; expected "int": "int"  [dict-item]
```

<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * IntelliJ IDEA 2021.2.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

I have no idea how to make `gradle check` pass, but the errors don't seem to be caused by my changes.

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
