### PR TITLE
Remove defunct JCenter/Bintray repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,8 @@ import org.commonmark.renderer.html.HtmlRenderer
 
 buildscript {
     repositories {
-        jcenter()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://dl.bintray.com/jetbrains/intellij-plugin-service' }
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.atlassian.commonmark:commonmark:0.11.0'
@@ -93,9 +92,8 @@ publishPlugin {
 }
 
 repositories {
-    jcenter()
-    maven { url "https://plugins.gradle.org/m2/" }
-    maven { url 'https://dl.bintray.com/jetbrains/intellij-plugin-service' }
+    mavenCentral()
+    gradlePluginPortal()
     if (hasPycharmPath) {
         flatDir {
             dirs "$pycharmPath/lib"


### PR DESCRIPTION
JCenter and Bintray have shut down: https://blog.gradle.org/jcenter-shutdown

Same change as I did in https://github.com/leinardi/pylint-pycharm/pull/83

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.2.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Related Issue

Same change as I did in https://github.com/leinardi/pylint-pycharm/pull/83
