### PR TITLE
Fix off-by-one error in column positions

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -335,7 +335,8 @@ public class MypyRunner {
                     String[] splitPosition = rawLine.substring(0, typeIndexStart - 1).split(":", -1);
                     String path = splitPosition[0].trim();
                     int line = splitPosition.length > 1 ? Integer.parseInt(splitPosition[1].trim()) : 1;
-                    int column = splitPosition.length > 2 ? Integer.parseInt(splitPosition[2].trim()) : 1;
+                    // Mypy uses 1-based column numbers, IntelliJ expects 0-based
+                    int column = splitPosition.length > 2 ? Integer.parseInt(splitPosition[2].trim()) - 1 : 1;
                     String[] splitError = rawLine.substring(typeIndexStart).split(":", 2);
                     SeverityLevel severityLevel = SeverityLevel.valueOf(splitError[0].trim().toUpperCase());
                     String message = splitError[1].trim();

--- a/src/test/java/com/leinardi/pycharm/mypy/mpapi/MypyRunnerTest.java
+++ b/src/test/java/com/leinardi/pycharm/mypy/mpapi/MypyRunnerTest.java
@@ -18,7 +18,7 @@ public class MypyRunnerTest {
     public void testParseWithColon() throws IOException {
         String message = "Dict entry 0 has incompatible type \"int\": \"str\"; expected \"int\": \"int\"  [dict-item]";
         String input = "path/testfile.py:1:22: error: " + message + "\n";
-        Issue parsed = new Issue("path/testfile.py", 1, 22, SeverityLevel.ERROR, message);
+        Issue parsed = new Issue("path/testfile.py", 1, 21, SeverityLevel.ERROR, message);
 
         List<Issue> results = MypyRunner.parseMypyOutput(stringToStream(input));
         Assert.assertArrayEquals(results.toArray(), new Issue[]{parsed});


### PR DESCRIPTION
Mypy uses 1-based column numbers, IntelliJ expects 0-based.

This got confusing in some situations, the highlight would appear in the wrong place for example when using single-letter variable names.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/137616/144715962-226057e4-1930-4925-a350-19b2fdd91ba4.png) | ![image](https://user-images.githubusercontent.com/137616/144715929-7840f26e-f5df-4616-89ba-4193546848e3.png) |

<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.2.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
