### PR TITLE
Make plugin hot-reloadable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,13 @@ intellij {
 
 runIde {
     systemProperties.put("idea.log.debug.categories", "#com.leinardi.pycharm.mypy")
+    // Log verbose information when dynamic plugin unloading fails
+    systemProperties.put("ide.plugins.snapshot.on.unload.fail", "true")
+}
+
+// Causes error popup when building while sandbox IDE is open. Disable in development
+if (System.getenv('DEVELOP')) {
+    buildSearchableOptions.enabled = false
 }
 
 patchPluginXml {

--- a/src/main/java/com/leinardi/pycharm/mypy/MypyAnnotator.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyAnnotator.java
@@ -82,7 +82,7 @@ public class MypyAnnotator extends ExternalAnnotator<MypyAnnotator.State, MypyAn
     private static final String ERROR_MESSAGE_INVALID_SYNTAX = "invalid syntax";
 
     private MypyPlugin plugin(final Project project) {
-        final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+        final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/MypyPlugin.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/MypyPlugin.java
@@ -16,7 +16,7 @@
 
 package com.leinardi.pycharm.mypy;
 
-import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -43,12 +43,8 @@ import static com.leinardi.pycharm.mypy.util.Async.whenFinished;
 /**
  * Main class for the Mypy scanning plug-in.
  */
-public final class MypyPlugin implements ProjectComponent {
-
-    /**
-     * The plugin ID. Caution: It must be identical to the String set in build.gradle at intellij.pluginName
-     */
-    public static final String ID_PLUGIN = "Mypy-PyCharm";
+@Service
+public final class MypyPlugin {
 
     private static final Logger LOG = com.intellij.openapi.diagnostic.Logger.getInstance(MypyPlugin.class);
 
@@ -92,22 +88,6 @@ public final class MypyPlugin implements ProjectComponent {
         synchronized (checksInProgress) {
             return !checksInProgress.isEmpty();
         }
-    }
-
-    @Override
-    public void projectOpened() {
-        LOG.debug("Project opened.");
-    }
-
-    @Override
-    public void projectClosed() {
-        LOG.debug("Project closed.");
-    }
-
-    @Override
-    @NotNull
-    public String getComponentName() {
-        return ID_PLUGIN;
     }
 
     public static void processErrorAndLog(@NotNull final String action, @NotNull final Throwable e) {

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/BaseAction.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/BaseAction.java
@@ -59,7 +59,7 @@ public abstract class BaseAction extends AnAction {
                 return;
             }
 
-            final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+            final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ClearAll.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ClearAll.java
@@ -38,7 +38,7 @@ public class ClearAll extends BaseAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/Close.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/Close.java
@@ -37,7 +37,7 @@ public class Close extends BaseAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/CollapseAll.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/CollapseAll.java
@@ -38,7 +38,7 @@ public class CollapseAll extends BaseAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayErrors.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayErrors.java
@@ -39,7 +39,7 @@ public class DisplayErrors extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }
@@ -63,7 +63,7 @@ public class DisplayErrors extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayNote.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayNote.java
@@ -39,7 +39,7 @@ public class DisplayNote extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }
@@ -63,7 +63,7 @@ public class DisplayNote extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayWarnings.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/DisplayWarnings.java
@@ -39,7 +39,7 @@ public class DisplayWarnings extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }
@@ -63,7 +63,7 @@ public class DisplayWarnings extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ExpandAll.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ExpandAll.java
@@ -38,7 +38,7 @@ public class ExpandAll extends BaseAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanCurrentChangeList.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanCurrentChangeList.java
@@ -51,7 +51,7 @@ public class ScanCurrentChangeList extends BaseAction {
             }
 
             final ChangeListManager changeListManager = ChangeListManager.getInstance(project);
-            project.getComponent(MypyPlugin.class)
+            project.getService(MypyPlugin.class)
                     .asyncScanFiles(VfUtil.filterOnlyPythonProjectFiles(project,
                             filesFor(changeListManager.getDefaultChangeList())));
         } catch (Throwable e) {
@@ -85,7 +85,7 @@ public class ScanCurrentChangeList extends BaseAction {
                 return;
             }
 
-            final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+            final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanCurrentFile.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanCurrentFile.java
@@ -46,7 +46,7 @@ public class ScanCurrentFile extends BaseAction {
 
         try {
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }
@@ -59,7 +59,7 @@ public class ScanCurrentFile extends BaseAction {
 
                     final VirtualFile selectedFile = getSelectedFile(project);
                     if (selectedFile != null) {
-                        project.getComponent(MypyPlugin.class).asyncScanFiles(
+                        project.getService(MypyPlugin.class).asyncScanFiles(
                                 Collections.singletonList(selectedFile));
                     }
 
@@ -111,7 +111,7 @@ public class ScanCurrentFile extends BaseAction {
             }
 
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanEverythingAction.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanEverythingAction.java
@@ -39,6 +39,6 @@ class ScanEverythingAction implements Runnable {
         filesToScan = VfUtil.flattenFiles(new VirtualFile[]{project.getBaseDir()});
         filesToScan = VfUtil.filterOnlyPythonProjectFiles(project, filesToScan);
 
-        project.getComponent(MypyPlugin.class).asyncScanFiles(filesToScan);
+        project.getService(MypyPlugin.class).asyncScanFiles(filesToScan);
     }
 }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanModifiedFiles.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanModifiedFiles.java
@@ -47,7 +47,7 @@ public class ScanModifiedFiles extends BaseAction {
             }
 
             final ChangeListManager changeListManager = ChangeListManager.getInstance(project);
-            project.getComponent(MypyPlugin.class).asyncScanFiles(
+            project.getService(MypyPlugin.class).asyncScanFiles(
                     VfUtil.filterOnlyPythonProjectFiles(project, changeListManager.getAffectedFiles())
             );
         } catch (Throwable e) {
@@ -66,7 +66,7 @@ public class ScanModifiedFiles extends BaseAction {
                 return;
             }
 
-            final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+            final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanModule.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanModule.java
@@ -58,7 +58,7 @@ public class ScanModule extends BaseAction {
             }
 
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }
@@ -107,7 +107,7 @@ public class ScanModule extends BaseAction {
             }
 
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanProject.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanProject.java
@@ -40,7 +40,7 @@ public class ScanProject extends BaseAction {
                 return;
             }
 
-            final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+            final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }
@@ -89,7 +89,7 @@ public class ScanProject extends BaseAction {
                 return;
             }
 
-            final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+            final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScanSourceRootsAction.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScanSourceRootsAction.java
@@ -34,7 +34,7 @@ class ScanSourceRootsAction implements Runnable {
 
     @Override
     public void run() {
-        project.getComponent(MypyPlugin.class)
+        project.getService(MypyPlugin.class)
                 .asyncScanFiles(VfUtil.filterOnlyPythonProjectFiles(project,
                         VfUtil.flattenFiles(sourceRoots)));
     }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/ScrollToSource.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/ScrollToSource.java
@@ -39,7 +39,7 @@ public final class ScrollToSource extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }
@@ -63,7 +63,7 @@ public final class ScrollToSource extends ToggleAction {
         }
 
         final MypyPlugin mypyPlugin
-                = project.getComponent(MypyPlugin.class);
+                = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/Settings.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/Settings.java
@@ -35,7 +35,7 @@ public class Settings extends BaseAction {
             return;
         }
 
-        final MypyPlugin mypyPlugin = project.getComponent(MypyPlugin.class);
+        final MypyPlugin mypyPlugin = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/java/com/leinardi/pycharm/mypy/actions/StopCheck.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/actions/StopCheck.java
@@ -39,7 +39,7 @@ public class StopCheck extends BaseAction {
 
         try {
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }
@@ -70,7 +70,7 @@ public class StopCheck extends BaseAction {
             }
 
             final MypyPlugin mypyPlugin
-                    = project.getComponent(MypyPlugin.class);
+                    = project.getService(MypyPlugin.class);
             if (mypyPlugin == null) {
                 throw new IllegalStateException("Couldn't get mypy plugin");
             }

--- a/src/main/java/com/leinardi/pycharm/mypy/handlers/ScanFilesBeforeCheckinHandler.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/handlers/ScanFilesBeforeCheckinHandler.java
@@ -101,7 +101,7 @@ public class ScanFilesBeforeCheckinHandler extends CheckinHandler {
             return COMMIT;
         }
 
-        final MypyPlugin plugin = project.getComponent(MypyPlugin.class);
+        final MypyPlugin plugin = project.getService(MypyPlugin.class);
         if (plugin == null) {
             LOG.warn("Could not get Mypy Plug-in, skipping");
             return COMMIT;

--- a/src/main/java/com/leinardi/pycharm/mypy/toolwindow/MypyToolWindowPanel.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/toolwindow/MypyToolWindowPanel.java
@@ -130,7 +130,7 @@ public class MypyToolWindowPanel extends JPanel {
         this.toolWindow = toolWindow;
         this.project = project;
 
-        mypyPlugin = project.getComponent(MypyPlugin.class);
+        mypyPlugin = project.getService(MypyPlugin.class);
         if (mypyPlugin == null) {
             throw new IllegalStateException("Couldn't get mypy plugin");
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,14 +26,6 @@
     <!--suppress PluginXmlValidity -->
     <depends>com.intellij.modules.python</depends>
 
-
-    <project-components>
-        <component>
-            <implementation-class>com.leinardi.pycharm.mypy.MypyPlugin</implementation-class>
-            <interface-class>com.leinardi.pycharm.mypy.MypyPlugin</interface-class>
-        </component>
-    </project-components>
-
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Mypy"
                     anchor="bottom"
@@ -41,8 +33,7 @@
                     factoryClass="com.leinardi.pycharm.mypy.toolwindow.MypyToolWindowFactory"
                     icon="/com/leinardi/pycharm/mypy/images/mypy.png"/>
 
-        <projectService serviceInterface="com.leinardi.pycharm.mypy.MypyConfigService"
-                        serviceImplementation="com.leinardi.pycharm.mypy.MypyConfigService"/>
+        <projectService serviceImplementation="com.leinardi.pycharm.mypy.MypyConfigService"/>
 
         <projectConfigurable instance="com.leinardi.pycharm.mypy.MypyConfigurable"/>
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am targeting the `master` branch (and **not** the `release` branch)
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
This allows the plugin to be (re)loaded without restarting the IDE, which is useful when developing the plugin and more convenient when upgrading.

There appear to be some issues in IntelliJ IDEA with dynamic unloading (IDEA-289241, IDEA-289243), but in the worst case, the user receives a message that they have to restart IDE to reload. Which was the norm previously.

Docs: https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
