### PR TITLE
Change default inspection level to ERROR

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,7 +54,7 @@
                          key="inspection.display-name"
                          groupKey="inspection.group"
                          shortName="Mypy"
-                         level="WARNING"
+                         level="ERROR"
                          unfair="true"
                          enabledByDefault="true"/>
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am targeting the `master` branch (and **not** the `release` branch)
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description

This was briefly discussed in https://github.com/leinardi/mypy-pycharm/pull/77#issuecomment-986020433 but reverted from that MR.

I have found that separating mypy inspections from PyCharm's own type checker is helpful, because PyCharm is more prone to false positives.

It's also familiar to users of IDEA TypeScript integration.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/137616/144709414-fd05e02d-2120-4192-9b79-9d93bc5469f9.png) | ![image](https://user-images.githubusercontent.com/137616/144709373-2f9b1a39-4bd8-4bb7-8479-db0c4718ddb7.png) |

It can also be changed from settings:

![image](https://user-images.githubusercontent.com/137616/144712889-4d13a09f-ba4e-445d-8284-d2873dec619f.png)

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :sparkles: New feature |
