### PR TITLE
Show notification when Mypy exits abnormally

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/util/Notifications.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/util/Notifications.java
@@ -123,6 +123,14 @@ public final class Notifications {
                 .notify(project);
     }
 
+    public static void showMypyAbnormalExit(final Project project, final String detail) {
+        BALLOON_GROUP
+                .createNotification(TITLE, detail, ERROR)
+                .setListener(URL_OPENING_LISTENER)
+                .setSubtitle(MypyBundle.message("plugin.notification.abnormal-exit.subtitle"))
+                .notify(project);
+    }
+
     public static void showNoPythonInterpreter(Project project) {
         Notification notification = BALLOON_GROUP
                 .createNotification(

--- a/src/main/resources/com/leinardi/pycharm/mypy/MypyBundle.properties
+++ b/src/main/resources/com/leinardi/pycharm/mypy/MypyBundle.properties
@@ -50,6 +50,7 @@ plugin.notification.unable-to-run-mypy.subtitle=Unable to run Mypy
 plugin.notification.unable-to-run-mypy.content=Mypy is installed inside the project environment but the plugin \
   is not able to run it. If you just installed it try to run File -> Synchronize or restart your IDE. \
   If the problem persists you may need to manually enter the path to the Mypy executable inside the Plugin settings.
+plugin.notification.abnormal-exit.subtitle=Mypy exited abormally
 plugin.notification.action.plugin-settings=Plugin settings
 plugin.notification.install-mypy.subtitle=Mypy missing
 plugin.notification.install-mypy.content=The project interpreter is missing Mypy, which is needed \


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am targeting the `master` branch (and **not** the `release` branch)
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description

Before this change, when mypy failed for some reason (some cases of invalid configuration, bugs in plugins of mypy, etc), the errors were hidden and no inspections would appear in IDE. This is bad because it may make buggy Python code look correct.

Now the following notification appears (the content is verbatim from mypy stderr output)

| Notification | When expanded |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/137616/154862401-46b6a056-32a0-4f94-b46b-3cd45fb394b3.png) | ![image](https://user-images.githubusercontent.com/137616/154862422-2e7d51b1-164e-4904-913e-d83694599b61.png) |
| ![image](https://user-images.githubusercontent.com/137616/154862224-0e6a1796-4f8f-4c34-9b81-9f89a705fb24.png) | ![image](https://user-images.githubusercontent.com/137616/154862245-a8a31106-ea71-4276-b6fb-6015bb4e140f.png) |

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Related Issue

Closes #60 -- or at least should help pinpointing the issue to get a better bug report.
