### PR TITLE
Update deprecated notifications API usage

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/util/Notifications.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/util/Notifications.java
@@ -18,6 +18,7 @@ package com.leinardi.pycharm.mypy.util;
 
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationGroupManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -37,8 +38,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import static com.intellij.notification.NotificationGroup.balloonGroup;
-import static com.intellij.notification.NotificationGroup.logOnlyGroup;
 import static com.intellij.notification.NotificationListener.URL_OPENING_LISTENER;
 import static com.intellij.notification.NotificationType.ERROR;
 import static com.intellij.notification.NotificationType.INFORMATION;
@@ -48,8 +47,10 @@ import static com.leinardi.pycharm.mypy.util.Exceptions.rootCauseOf;
 
 public final class Notifications {
     private static final Logger LOG = com.intellij.openapi.diagnostic.Logger.getInstance(Notifications.class);
-    private static final NotificationGroup BALLOON_GROUP = balloonGroup(message("plugin.notification.alerts"));
-    private static final NotificationGroup LOG_ONLY_GROUP = logOnlyGroup(message("plugin.notification.logging"));
+    private static final NotificationGroup BALLOON_GROUP =
+            NotificationGroupManager.getInstance().getNotificationGroup("alerts");
+    private static final NotificationGroup LOG_ONLY_GROUP =
+            NotificationGroupManager.getInstance().getNotificationGroup("logging");
     private static final String TITLE = message("plugin.name");
 
     private Notifications() {
@@ -57,43 +58,36 @@ public final class Notifications {
 
     public static void showInfo(final Project project, final String infoText) {
         BALLOON_GROUP
-                .createNotification(TITLE, infoText, INFORMATION, URL_OPENING_LISTENER)
-                .notify(project);
-    }
-
-    public static void showInfo(final Project project, final String title, final String infoText) {
-        BALLOON_GROUP
-                .createNotification(title, infoText, INFORMATION, URL_OPENING_LISTENER)
+                .createNotification(TITLE, infoText, INFORMATION)
+                .setListener(URL_OPENING_LISTENER)
                 .notify(project);
     }
 
     public static void showWarning(final Project project, final String warningText) {
         BALLOON_GROUP
-                .createNotification(TITLE, warningText, WARNING, URL_OPENING_LISTENER)
+                .createNotification(TITLE, warningText, WARNING)
+                .setListener(URL_OPENING_LISTENER)
                 .notify(project);
     }
 
     public static void showWarning(final Project project, final String title, final String warningText) {
         BALLOON_GROUP
-                .createNotification(title, warningText, WARNING, URL_OPENING_LISTENER)
+                .createNotification(title, warningText, WARNING)
+                .setListener(URL_OPENING_LISTENER)
                 .notify(project);
     }
 
     public static void showError(final Project project, final String errorText) {
         BALLOON_GROUP
-                .createNotification(TITLE, errorText, ERROR, URL_OPENING_LISTENER)
-                .notify(project);
-    }
-
-    public static void showError(final Project project, final String title, final String errorText) {
-        BALLOON_GROUP
-                .createNotification(title, errorText, ERROR, URL_OPENING_LISTENER)
+                .createNotification(TITLE, errorText, ERROR)
+                .setListener(URL_OPENING_LISTENER)
                 .notify(project);
     }
 
     public static void showException(final Project project, final Throwable t) {
         LOG_ONLY_GROUP
-                .createNotification(message("plugin.exception"), messageFor(t), ERROR, URL_OPENING_LISTENER)
+                .createNotification(message("plugin.exception"), messageFor(t), ERROR)
+                .setListener(URL_OPENING_LISTENER)
                 .notify(project);
     }
 
@@ -101,10 +95,10 @@ public final class Notifications {
         Notification notification = BALLOON_GROUP
                 .createNotification(
                         TITLE,
-                        MypyBundle.message("plugin.notification.install-mypy.subtitle"),
                         MypyBundle.message("plugin.notification.install-mypy.content"),
-                        ERROR,
-                        URL_OPENING_LISTENER);
+                        ERROR)
+                .setSubtitle(MypyBundle.message("plugin.notification.install-mypy.subtitle"))
+                .setListener(URL_OPENING_LISTENER);
         notification
                 .addAction(new InstallMypyAction(project, notification))
                 .notify(project);
@@ -114,10 +108,10 @@ public final class Notifications {
         Notification notification = BALLOON_GROUP
                 .createNotification(
                         TITLE,
-                        MypyBundle.message("plugin.notification.unable-to-run-mypy.subtitle"),
                         MypyBundle.message("plugin.notification.unable-to-run-mypy.content"),
-                        ERROR,
-                        URL_OPENING_LISTENER);
+                        ERROR)
+                .setSubtitle(MypyBundle.message("plugin.notification.unable-to-run-mypy.subtitle"))
+                .setListener(URL_OPENING_LISTENER);
         notification
                 .addAction(new OpenPluginSettingsAction(notification))
                 .notify(project);
@@ -128,8 +122,8 @@ public final class Notifications {
                 .createNotification(
                         TITLE,
                         MypyBundle.message("plugin.notification.no-python-interpreter.content"),
-                        ERROR,
-                        URL_OPENING_LISTENER);
+                        ERROR)
+                .setListener(URL_OPENING_LISTENER);
         notification
                 .addAction(new ConfigurePythonInterpreterAction(project, notification))
                 .notify(project);
@@ -153,7 +147,7 @@ public final class Notifications {
     }
 
     private static class OpenPluginSettingsAction extends AnAction {
-        private Notification notification;
+        private final Notification notification;
 
         OpenPluginSettingsAction(Notification notification) {
             super(MypyBundle.message("plugin.notification.action.plugin-settings"));
@@ -161,15 +155,15 @@ public final class Notifications {
         }
 
         @Override
-        public void actionPerformed(AnActionEvent event) {
+        public void actionPerformed(@NotNull AnActionEvent event) {
             new Settings().actionPerformed(event);
             notification.expire();
         }
     }
 
     private static class ConfigurePythonInterpreterAction extends AnAction {
-        private Project project;
-        private Notification notification;
+        private final Project project;
+        private final Notification notification;
 
         ConfigurePythonInterpreterAction(Project project, Notification notification) {
             super(MypyBundle.message("plugin.notification.action.configure-python-interpreter"));
@@ -178,15 +172,15 @@ public final class Notifications {
         }
 
         @Override
-        public void actionPerformed(AnActionEvent ignored) {
+        public void actionPerformed(@NotNull AnActionEvent ignored) {
             ShowSettingsUtil.getInstance().showSettingsDialog(project, "Project Interpreter");
             notification.expire();
         }
     }
 
     private static class InstallMypyAction extends AnAction {
-        private Project project;
-        private Notification notification;
+        private final Project project;
+        private final Notification notification;
 
         InstallMypyAction(Project project, Notification notification) {
             super(MypyBundle.message("plugin.notification.action.install-mypy"));
@@ -195,7 +189,7 @@ public final class Notifications {
         }
 
         @Override
-        public void actionPerformed(AnActionEvent ignored) {
+        public void actionPerformed(@NotNull AnActionEvent ignored) {
             Sdk projectSdk = ProjectRootManager.getInstance(project).getProjectSdk();
             if (projectSdk == null) {
                 LOG.debug("Project interpreter not set");

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
     <!--suppress PluginXmlValidity -->
     <depends>com.intellij.modules.python</depends>
 
+    <resource-bundle>com.leinardi.pycharm.mypy.MypyBundle</resource-bundle>
 
     <project-components>
         <component>
@@ -50,7 +51,6 @@
 
         <localInspection implementationClass="com.leinardi.pycharm.mypy.MypyBatchInspection"
                          language="Python"
-                         bundle="com.leinardi.pycharm.mypy.MypyBundle"
                          key="inspection.display-name"
                          groupKey="inspection.group"
                          shortName="Mypy"
@@ -60,6 +60,9 @@
 
         <checkinHandlerFactory id="CheckStyleIDEACheckInHandlerFactory"
                                implementation="com.leinardi.pycharm.mypy.handlers.ScanFilesBeforeCheckinHandlerFactory"/>
+
+        <notificationGroup id="alerts" displayType="BALLOON" key="plugin.notification.alerts"/>
+        <notificationGroup id="logging" displayType="NONE" key="plugin.notification.logging"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am targeting the `master` branch (and **not** the `release` branch)
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.3
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
* Notification groups are now defined in plugin.xml
* `createNotification()` method with over 4 arguments are deprecated
* Deleted unused methods in `Notifications` & fixed IntelliJ inspections

Docs: https://plugins.jetbrains.com/docs/intellij/notifications.html#top-level-notifications-balloons

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :hammer: Refactoring  |
