### PR TITLE
Respect custom mypy path when checking for mypy availability

### DIFF
--- a/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
+++ b/src/main/java/com/leinardi/pycharm/mypy/mpapi/MypyRunner.java
@@ -164,7 +164,13 @@ public class MypyRunner {
                 Notifications.showNoPythonInterpreter(project);
             }
             return false;
-        } else if (showNotifications) {
+        }
+        MypyConfigService mypyConfigService = MypyConfigService.getInstance(project);
+        if (mypyConfigService == null) {
+            throw new IllegalStateException("MypyConfigService is null");
+        }
+        String mypyPath = getMypyPath(project);
+        if (mypyPath.isEmpty() && showNotifications) {
             PyPackageManager pyPackageManager = PyPackageManager.getInstance(projectSdk);
             List<PyPackage> packages = pyPackageManager.getPackages();
             if (packages != null) {
@@ -174,11 +180,6 @@ public class MypyRunner {
                 }
             }
         }
-        MypyConfigService mypyConfigService = MypyConfigService.getInstance(project);
-        if (mypyConfigService == null) {
-            throw new IllegalStateException("MypyConfigService is null");
-        }
-        String mypyPath = getMypyPath(project);
         boolean isMypyPathValid = !mypyPath.isEmpty() && isMypyPathValid(mypyPath, project);
         if (showNotifications && !isMypyPathValid) {
             Notifications.showUnableToRunMypy(project);


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](https://github.com/leinardi/mypy-pycharm/blob/release/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am targeting the `master` branch (and **not** the `release` branch)
- [x] I am using the provided [codeStyleConfig.xml](https://github.com/leinardi/mypy-pycharm/blob/release/.idea/codeStyles/codeStyleConfig.xml)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm Community 2021.3.1
 * IntelliJ IDEA 2021.3.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
* Function checkMypyAvailable is called from various places in the code. If user specifies a custom mypy executable, which is not part of project's venv, then this function will return false when called with showNotifications == true. This happens because the function checks for mypy presence in the project's venv and it doesn't respect the custom path. This change makes the function check for mypy in the project's venv only if no custom path is present.
* Additional note. It may be better to check for mypy presence in the current venv after isMypyPathValid call. Thus, a user would get two notifications: mypy is not available, click here to install it.


### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |
|   | :sparkles: New feature |
|   | :hammer: Refactoring  |
|   | :scroll: Docs |

### Related Issue

<!-- 
If this PR fixes a particular issue, use the following to automatically close that issue
once this PR gets merged:
-->
Closes #98 